### PR TITLE
fix matchlabel for example

### DIFF
--- a/examples/k8s/alert-rules-team1.yaml
+++ b/examples/k8s/alert-rules-team1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: alert-rules-team1
   namespace: default
   labels:
-    type: alert-rules
+    type: prometheus-alerts
 data:
   alerts1.yml: |
     groups:


### PR DESCRIPTION
There is a wrong matchlabel in the example alert configmap. 