### PR TITLE
Avoid doing query on nodes on all namespaces

### DIFF
--- a/cmd/trovilo/main.go
+++ b/cmd/trovilo/main.go
@@ -60,8 +60,8 @@ func main() {
 	}
 	log.Debug("Successfully loaded Kubernetes client")
 
-	log.Debug("Testing Kubernetes connectivity by fetching list of nodes..")
-	if err := client.List(context.Background(), "", new(corev1.NodeList)); err != nil {
+	log.Debug("Testing Kubernetes connectivity by fetching list of configmaps..")
+	if err := client.List(context.Background(), config.Namespace, new(corev1.ConfigMapList)); err != nil {
 		log.WithError(err).Fatal("Failed to test Kubernetes connectivity")
 	}
 	log.Debug("Successfully tested Kubernetes connectivity")


### PR DESCRIPTION
As a normal user on OpenShift, I don't have the permissions to list
nodes (silly, I know, but it's life).

This makes the Kubernetes connection check stop listing nodes, but just lists
configmaps (if I can watch, there is a big probability I can list).